### PR TITLE
Fix Twig `message()` filter

### DIFF
--- a/src/Middleware/TwigMessageExtension.php
+++ b/src/Middleware/TwigMessageExtension.php
@@ -53,6 +53,6 @@ class TwigMessageExtension extends AbstractExtension {
 			// Unwrap args array
 			$params = $params[0];
 		}
-		return $this->intuition->msg( $key, $params );
+		return $this->intuition->msg( $key, [ 'variables' => $params ] );
 	}
 }


### PR DESCRIPTION
Correct the passing of i18n message parameters.

Bug: T370133